### PR TITLE
Convert TinyTag object to a dict before appending to `to_encode`

### DIFF
--- a/overseer.py
+++ b/overseer.py
@@ -93,10 +93,12 @@ def main(argv):
         track_absolute_path = destination + '/' + track_relative_path
 
         if track_relative_path and not os.path.exists(track_absolute_path):
+            tags_dict = dict((k, v)
+                    for k, v in tags.__dict__.items() if not k.startswith('_'))
             to_encode.append({
                 'source': source_file,
                 'destination': track_absolute_path,
-                'tags': tags
+                'tags': tags_dict
             })
         else:
             print('Ignoring ' + source_file)


### PR DESCRIPTION
Fixes #1.

Source: https://github.com/devsnd/tinytag/blob/master/tinytag/tinytag.py#L89
